### PR TITLE
Fix repository links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,21 +2,21 @@
   "name": "is-dotfile",
   "description": "Return true if a file path is (or has) a dotfile.",
   "version": "1.0.0",
-  "homepage": "https://github.com/regexps/is-dotfile",
+  "homepage": "https://github.com/jonschlinkert/is-dotfile",
   "author": {
     "name": "Jon Schlinkert",
     "url": "https://github.com/jonschlinkert"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/regexps/is-dotfile.git"
+    "url": "git://github.com/jonschlinkert/is-dotfile.git"
   },
   "bugs": {
-    "url": "https://github.com/regexps/is-dotfile/issues"
+    "url": "https://github.com/jonschlinkert/is-dotfile/issues"
   },
   "license": {
     "type": "MIT",
-    "url": "https://github.com/regexps/is-dotfile/blob/master/LICENSE-MIT"
+    "url": "https://github.com/jonschlinkert/is-dotfile/blob/master/LICENSE"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
While trying to use [WebJars](https://github.com/webjars/webjars) with this package, was getting errors because the package.json was not resolving to the correct github repository.

Unsure if this should have included a patch version bump for syncing w/ npmjs. Can add if desired.
